### PR TITLE
Feature request/idea: add support for a folder description field

### DIFF
--- a/app/assets/stylesheets/blacklight_folders/_folders.css.scss
+++ b/app/assets/stylesheets/blacklight_folders/_folders.css.scss
@@ -54,3 +54,7 @@ $table_border: 1px dotted $table-border-color;
   text-align: center;
 }
 
+#folder_name {
+  margin-bottom: 15px;
+}
+

--- a/app/controllers/blacklight/folders/folders_controller.rb
+++ b/app/controllers/blacklight/folders/folders_controller.rb
@@ -134,7 +134,7 @@ module Blacklight::Folders
 	    end
 
       def create_params
-        params.require(:folder).permit(:name, :visibility, items_attributes: [:id, :position, :_destroy, :folder_id])
+        params.require(:folder).permit(:name, :description, :visibility, items_attributes: [:id, :position, :_destroy, :folder_id])
       end
 
       def clear_session_search_params

--- a/app/views/blacklight/folders/folders/_form.html.erb
+++ b/app/views/blacklight/folders/folders/_form.html.erb
@@ -18,6 +18,10 @@
         <div class="col-sm-10">
           <%= f.text_field :name, class: 'form-control' %>
         </div>
+        <%= f.label :description, class: 'col-sm-2 control-label' %>
+        <div class="col-sm-10">
+          <%= f.text_area :description, class: 'form-control' %>
+        </div>
       </div>
 
       <div class="form-group">

--- a/app/views/blacklight/folders/folders/show.html.erb
+++ b/app/views/blacklight/folders/folders/show.html.erb
@@ -9,6 +9,13 @@
      </div>
   <% end %>
   <h1><%= @folder.name %></h1>
+
+  <div>
+    <% if @folder.description %>
+      <span class="description-label"><%= t("blacklight/folders/folder.description", scope: "helpers.label") %>:</span> <span class="description"><%= sanitize @folder.description %></span>
+    <% end %>
+  </div>
+
   <div>
     <span class="owner-label"><%= t("blacklight/folders/folder.user", scope: "helpers.label") %>:</span> <span class="owner"><%= @folder.user.guest? ? 'Guest' : @folder.user %></span>
   </div>

--- a/config/locales/blacklight_folders.en.yml
+++ b/config/locales/blacklight_folders.en.yml
@@ -27,6 +27,7 @@ en:
         visibility: "Visibility"
         created: "Created"
         updated: "Updated"
+        description: "Description"
   activerecord:
     models:
       blacklight/folders/folder_item: Item

--- a/db/migrate/20141222223103_add_description_to_folders.rb
+++ b/db/migrate/20141222223103_add_description_to_folders.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToFolders < ActiveRecord::Migration
+  def change
+     add_column :blacklight_folders_folders, :description, :text
+  end
+end

--- a/lib/generators/blacklight_folders/install_generator.rb
+++ b/lib/generators/blacklight_folders/install_generator.rb
@@ -17,6 +17,12 @@ module BlacklightFolders
       rake "db:migrate"
     end
 
+    def add_configurations
+      insert_into_file 'config/application.rb', after: "< Rails::Application\n" do
+        "    config.action_view.sanitized_allowed_tags = ['b', 'ol', 'li', 'br', 'p', 'strong', 'h1', 'h2', 'img', 'a']\n"
+      end
+    end
+
     def add_model_mixins
       inject_into_class 'app/models/user.rb', User, '  include Blacklight::Folders::User'
       inject_into_class 'app/models/solr_document.rb', SolrDocument, '  include Blacklight::Folders::SolrDocument'


### PR DESCRIPTION
First, thanks for releasing this project. It is extremely well-timed for a project we are working on at the moment and will save us a ton of work :gift_heart:.

For the purposes of our project, we would like to also provide a place for users to describe their folder. I am curious if this feature might be desirable for users outside of our project. 

Side note: apologies, I am new to rails engines and haven't had a chance to grok engine testing just yet. I will add some tests to my fork this coming week. But, I figured I'd run this feature by you before I got too far down the road in order to just to see if there was any interest in adding this to BL folders.

Alternatively, strategies other than including  this or other feature extensions directly into BL folders are also welcomed and appreciated (e.g. a BL Folders "extras" engine that I include along side BL folders vs directly customizing them in our app).

Thanks again, and happy holidays.
