### PR TITLE
Redirect to main_app.root_url with error message when folder not found

### DIFF
--- a/app/controllers/blacklight/folders/folders_controller.rb
+++ b/app/controllers/blacklight/folders/folders_controller.rb
@@ -8,7 +8,12 @@ module Blacklight::Folders
     load_and_authorize_resource class: Blacklight::Folders::Folder, except: [:add_bookmarks, :remove_bookmarks]
     before_filter :load_and_authorize_folder, only: [:add_bookmarks, :remove_bookmarks]
     before_filter :clear_session_search_params, only: [:show]
-
+    rescue_from ActiveRecord::RecordNotFound do |exception|
+      params.delete :id
+      flash[:error] = "The folder you are trying to access doesn't exist."
+      redirect_to main_app.root_url
+    end
+    
     def index
       @folders = if current_or_guest_user.new_record?
         # Just show the temporary folder


### PR DESCRIPTION
Hi, 

We found a problem a user tries to access a folder that doesn't exist or has been deleted. It throws an error: ActiveRecord::RecordNotFound in Blacklight::Folders::FoldersController#show

We'd like to catch this error and provide a helpful message. This fix does that. 

Thanks

David Jiao
Indiana University Enterprise Library Systems