### PR TITLE
redirects to main_app.root_url when folder id is invalid

### DIFF
--- a/app/controllers/blacklight/folders/folders_controller.rb
+++ b/app/controllers/blacklight/folders/folders_controller.rb
@@ -8,6 +8,11 @@ module Blacklight::Folders
     load_and_authorize_resource class: Blacklight::Folders::Folder, except: [:add_bookmarks, :remove_bookmarks]
     before_filter :load_and_authorize_folder, only: [:add_bookmarks, :remove_bookmarks]
     before_filter :clear_session_search_params, only: [:show]
+    rescue_from ActiveRecord::RecordNotFound do |exception|
+      params.delete :id
+      flash[:error] = t(:'blacklight.folders.show.invalid_folder_id')
+      redirect_to main_app.root_url
+    end
 
     def index
       @folders = if current_or_guest_user.new_record?

--- a/config/locales/blacklight_folders.en.yml
+++ b/config/locales/blacklight_folders.en.yml
@@ -51,6 +51,7 @@ en:
             prompt: "Select a Folder"
         folder_controls:
           contained_in: 'This item is contained in:'
+        invalid_folder_id: "The folder you are trying to access doesn't exist."
       folders:
         edit:
           header: "Manage Folder"

--- a/spec/controllers/blacklight/folders/folders_controller_spec.rb
+++ b/spec/controllers/blacklight/folders/folders_controller_spec.rb
@@ -28,6 +28,11 @@ describe Blacklight::Folders::FoldersController do
         get :show, id: my_private_folder.id
         expect(response).to redirect_to(main_app.user_session_path)
       end
+
+      it 'redirects to home page for invalid folder id' do
+        get :show, id: 100000000000
+        expect(response).to redirect_to(main_app.root_path)
+      end
     end
 
     describe '#edit' do


### PR DESCRIPTION
We found a problem a user tries to access a folder that doesn't exist or has been deleted. It throws an error: ActiveRecord::RecordNotFound in Blacklight::Folders::FoldersController#show

We'd like to catch this error, redirect to root_url with a helpful message. This fix does that. 

This is a resubmit of the previous pull request #98 